### PR TITLE
performance improvement

### DIFF
--- a/cpplua.hpp
+++ b/cpplua.hpp
@@ -1,68 +1,79 @@
 #ifndef LUACPP_H
 #define LUACPP_H
-#include <iostream>
-#include <vector>
-#include <filesystem>
-#include <fstream>
+
+#include <map>
 #include <regex>
-#include <sstream>
+#include <fstream>
 
 namespace cpp {
   class luaparsing {
-
     public:
-      std::string luafile;
+      luaparsing() = delete;
+      luaparsing(const std::string& filepath) : luafile(filepath) {}
 
-      luaparsing(){
-        this->key = "key";
-        this->value = "value";
-        this->luafile = "";
-      }
+      void parse() {
+        std::ifstream file;
+        file.open(luafile);
 
-      std::string get_value_from_key(const std::string& key){
-        this->action = this->key;
-        this->name = key;
-        return this->readluafile();
-      }
-
-      std::string get_key_from_value(const std::string& value){
-        this->action = this->value;
-        this->name = value;
-        return this->readluafile();
-      }
-
-      std::string readluafile(){
-        this->file.open( this->luafile);
-        if( this->file.is_open() && this->check_ext() ){
-          while( std::getline( this->file, this->line ) ){
-            this->line = remove_comments();
-            this->line = empty_lines(this->line);
-            this->line = remove_quotes();
-            if( !this->line.empty() ){
-              if( this->action == "key"){
-                if( show_kv( this->line, 0 ) == this->name){
-                  return show_kv( this->line, 1 );
-                }
-              }else if( this->action == "value"){
-                if( show_kv( this->line, 1 ) == this->name){
-                  return show_kv( this->line, 0 );
-                }
-              }else{
-                this->output << this->line << '\n';
-              }
-            }
-          }
-          this->file.close();
-        }else{
-          this->output << "Failed to open file.\n";
+        if (!file.is_open()) {
+          file.close();
+          return;
         }
-        return this->output.str();
+
+        if (!this->check_ext()) {
+          return;
+        }
+
+        auto trim = [](std::string& str) {
+          str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](unsigned char ch) {
+              return !std::isspace(ch);
+          }));
+
+          str.erase(std::find_if(str.rbegin(), str.rend(), [](unsigned char ch) {
+              return !std::isspace(ch);
+          }).base(), str.end());
+        };
+
+        while(std::getline(file, this->currentLine)){
+          this->currentLine = remove_comments();
+          this->currentLine = empty_lines(this->currentLine);
+          this->currentLine = remove_quotes();
+
+          if(!this->currentLine.empty()){
+            std::regex pair("(.*)=(.*)");
+
+            std::string key = std::regex_replace(currentLine, pair, "$1");
+            std::string value = std::regex_replace(currentLine, pair, "$2");
+            
+            trim(key);
+            trim(value);
+
+            luaVars[key] = value;
+          }
+        }
+
+        file.close();
       }
 
-    private:
-      std::ifstream file;
-      std::string line,token,key,value,action,name;
-      std::stringstream output;
+      std::string get_value_from_key(const std::string& key) const {
+        auto it = luaVars.find(key);
+
+        if (it == luaVars.end()) {
+          return "null";
+        }
+
+        return luaVars.at(key);
+      }
+
+      std::string get_key_from_value(const std::string& value) const {
+        for (auto it = luaVars.begin(); it != luaVars.end(); ++it) {
+          if (it->second == value) {
+            return it->first;
+          }
+        }
+
+        return "null";
+      }
 
     protected:
       bool check_ext(){
@@ -71,9 +82,9 @@ namespace cpp {
 
       const std::string remove_comments(){
         std::regex comment("(.*)--(.*)");
-        return std::regex_replace( this->line, comment, "$1");
+        return std::regex_replace( this->currentLine, comment, "$1");
       }
-     
+
       const std::string empty_lines(const std::string& line){
         std::regex blank("^( +)?(.*)( +)?$");
         return std::regex_replace( line, blank, "$2");
@@ -81,20 +92,13 @@ namespace cpp {
 
       const std::string remove_quotes(){
         std::regex quotes("\"");
-        return std::regex_replace( this->line, quotes, "");
+        return std::regex_replace( this->currentLine, quotes, "");
       }
 
-      const std::string show_kv(std::string line,const int& kv){
-        std::regex keys("(.*)=(.*)");
-        if( kv == 0 ){
-          line.erase( std::remove( line.begin() , line.end(), ' ') , line.end() );
-          this->token = std::regex_replace( line, keys, "$1");
-        }else{
-          this->token = std::regex_replace( line, keys, "$2");
-          this->token = empty_lines( this->token);
-        }
-        return this->token;
-      }
+      std::string luafile;
+      std::string currentLine;
+      std::map<std::string, std::string> luaVars;
   };
 }
+
 #endif


### PR DESCRIPTION
Os métodos **get_value_from_key** e **get_key_from_value** faziam I/O em disco e realizavam toda a leitura do arquivo para extrair uma chave ou um valor. O usuário não espera que um método get realize todas essas operações. Idealmente, o parse do arquivo deveria ser feito uma única vez as chaves/valores extraídos armazenados em cache (luaVars). De fato, para acessar uma mesma chave duas vezes, todo o processo de leitura e parse do arquivo estava sendo feito 2 vezes também, o que é um overhead desnecessário e inesperado para o código cliente.

Para pequenas amostras a diferença é desprezível, porém conforme a utilização cresce, torna-se um gargalo muito grande, seja por um arquivo .lua extenso, seja por acessos repetidos a uma mesma chave/valor. Pode-se verificar isso fazendo o acesso de uma mesma chave dentro de um loop e marcando o tempo de execução com a chrono para observar os ganhos.